### PR TITLE
Added CRL and OCSP

### DIFF
--- a/src/main/java/information/security/informationsecurity/controller/certificate/CRLController.java
+++ b/src/main/java/information/security/informationsecurity/controller/certificate/CRLController.java
@@ -1,0 +1,46 @@
+package information.security.informationsecurity.controller.certificate;
+
+import information.security.informationsecurity.service.certificate.CRLService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/pki/crl")
+@RequiredArgsConstructor
+@CrossOrigin
+public class CRLController {
+    private final CRLService service;
+
+    /**
+     * Get CRL for specific CA certificate
+     * */
+    @GetMapping(value = "/{caId}", produces = "application/pkcs7-crl")
+    public ResponseEntity<byte[]> getCRL(@PathVariable Long caId) {
+        try {
+            byte[] crlBytes = service.generateCRL(caId);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType("application/pkcs7-crl"))
+                    .header("Content-Disposition", "attachment; filename=ca-" + caId + ".crl")
+                    .body(crlBytes);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * Get CRL in PEM format
+     * */
+    @GetMapping(value = "/{caId}/pem", produces = "application/x-pem-file")
+    public ResponseEntity<String> getCRLPEM(@PathVariable Long caId) {
+        try {
+            String crlPem = service.generateCRLPEM(caId);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType("application/x-pem-file"))
+                    .body(crlPem);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/information/security/informationsecurity/controller/certificate/OCSPController.java
+++ b/src/main/java/information/security/informationsecurity/controller/certificate/OCSPController.java
@@ -1,0 +1,58 @@
+package information.security.informationsecurity.controller.certificate;
+
+import information.security.informationsecurity.service.certificate.OCSPService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/pki/ocsp")
+@RequiredArgsConstructor
+@CrossOrigin
+public class OCSPController {
+    private final OCSPService service;
+
+    /**
+     * OCSP Request via POST (binary)
+     */
+    @PostMapping(consumes = "application/ocsp-request", produces = "application/ocsp-response")
+    public ResponseEntity<byte[]> handleOCSPRequest(@RequestBody byte[] ocspRequest) {
+        try {
+            byte[] ocspResponse = service.processOCSPRequest(ocspRequest);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType("application/ocsp-response"))
+                    .body(ocspResponse);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    /**
+     * OCSP Request via GET (Base64 encoded)
+     */
+    @GetMapping("/{encodedRequest}")
+    public ResponseEntity<byte[]> handleOCSPRequest(@PathVariable String encodedRequest) {
+        try {
+            byte[] ocspResponse = service.processOCSPRequestFromBase64(encodedRequest);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType("application/ocsp-response"))
+                    .body(ocspResponse);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    /**
+     * Check certificate status via simple GET
+     */
+    @GetMapping("/status/{serialNumber}")
+    public ResponseEntity<String> getCertificateStatus(@PathVariable String serialNumber) {
+        try {
+            boolean revoked = service.isCertificateRevoked(serialNumber);
+            return ResponseEntity.ok(revoked ? "REVOKED" : "GOOD");
+        } catch (Exception e) {
+            return ResponseEntity.ok("UNKNOWN");
+        }
+    }
+}

--- a/src/main/java/information/security/informationsecurity/repository/certificate/CertificateRepository.java
+++ b/src/main/java/information/security/informationsecurity/repository/certificate/CertificateRepository.java
@@ -60,5 +60,5 @@ public interface CertificateRepository extends JpaRepository<Certificate, Long> 
     @Query("SELECT c FROM Certificate c WHERE c.subjectDN LIKE %:commonName% AND c.revoked = false")
     List<Certificate> findByCommonName(@Param("commonName") String commonName);
 
-
+    List<Certificate> findByIssuerCertificateAndRevokedTrue(Certificate issuerCertificate);
 }

--- a/src/main/java/information/security/informationsecurity/service/certificate/CRLService.java
+++ b/src/main/java/information/security/informationsecurity/service/certificate/CRLService.java
@@ -1,0 +1,96 @@
+package information.security.informationsecurity.service.certificate;
+
+import information.security.informationsecurity.model.certificate.Certificate;
+import information.security.informationsecurity.repository.certificate.CertificateRepository;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.CRLReason;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.X509CRLHolder;
+import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.springframework.stereotype.Service;
+
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CRLService {
+    private final CertificateRepository certificateRepository;
+    private final CryptographyService cryptographyService;
+
+    public byte[] generateCRL(long caId) throws Exception {
+        Certificate caCertificate = certificateRepository.findById(caId)
+                .orElseThrow(() -> new RuntimeException("CA certificate not found"));
+
+        // Get all revoked certificates issued by this CA
+        List<Certificate> revokedCertificates = certificateRepository
+                .findByIssuerCertificateAndRevokedTrue(caCertificate);
+
+        // Build CRL
+        X500Name issuerName = new X500Name(caCertificate.getSubjectDN());
+        Date thisUpdate = new Date();
+        Date nextUpdate = new Date(System.currentTimeMillis() + (24 * 60 * 60 * 1000)); // 24 hours
+
+        X509v2CRLBuilder crlBuilder = new X509v2CRLBuilder(issuerName, thisUpdate);
+        crlBuilder.setNextUpdate(nextUpdate);
+
+        // Add revoked certificates
+        for (Certificate revokedCert : revokedCertificates) {
+            BigInteger serialNumber = new BigInteger(revokedCert.getSerialNumber());
+            Date revocationDate = Date.from(revokedCert.getRevocationDate()
+                    .atZone(ZoneId.systemDefault()).toInstant());
+
+            int reasonCode = mapRevocationReasonToCRLReason(revokedCert.getRevocationReason());
+            crlBuilder.addCRLEntry(serialNumber, revocationDate, reasonCode);
+        }
+
+        // Add CRL Number extension
+        long crlNumber = System.currentTimeMillis() / 1000; // Simple CRL numbering
+        crlBuilder.addExtension(Extension.cRLNumber, false,
+                new org.bouncycastle.asn1.ASN1Integer(crlNumber));
+
+        // Sign CRL
+        java.security.PrivateKey signingKey = cryptographyService.getDecryptedPrivateKey(caCertificate);
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider("BC").build(signingKey);
+
+        X509CRLHolder crlHolder = crlBuilder.build(signer);
+        return crlHolder.getEncoded();
+    }
+
+    public String generateCRLPEM(Long caId) throws Exception {
+        byte[] crlBytes = generateCRL(caId);
+        java.security.cert.CertificateFactory cf = java.security.cert.CertificateFactory.getInstance("X.509", "BC");
+        java.security.cert.X509CRL x509CRL = (java.security.cert.X509CRL) cf.generateCRL(new java.io.ByteArrayInputStream(crlBytes));
+
+        StringWriter stringWriter = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(stringWriter)) {
+            pemWriter.writeObject(x509CRL);
+        }
+        return stringWriter.toString();
+    }
+
+    private int mapRevocationReasonToCRLReason(
+            information.security.informationsecurity.model.certificate.RevocationReason reason) {
+        if (reason == null) {
+            return CRLReason.unspecified;
+        }
+
+        return switch (reason) {
+            case KEY_COMPROMISE -> CRLReason.keyCompromise;
+            case CA_COMPROMISE -> CRLReason.cACompromise;
+            case AFFILIATION_CHANGED -> CRLReason.affiliationChanged;
+            case SUPERSEDED -> CRLReason.superseded;
+            case CESSATION_OF_OPERATION -> CRLReason.cessationOfOperation;
+            case CERTIFICATE_HOLD -> CRLReason.certificateHold;
+            default -> CRLReason.unspecified;
+        };
+    }
+}

--- a/src/main/java/information/security/informationsecurity/service/certificate/OCSPService.java
+++ b/src/main/java/information/security/informationsecurity/service/certificate/OCSPService.java
@@ -1,0 +1,188 @@
+package information.security.informationsecurity.service.certificate;
+
+import information.security.informationsecurity.model.certificate.Certificate;
+import information.security.informationsecurity.repository.certificate.CertificateRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.ocsp.ResponderID;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers;
+import org.bouncycastle.cert.ocsp.*;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class OCSPService {
+
+    private final CertificateRepository certificateRepository;
+    private final CryptographyService cryptographyService;
+
+    /**
+     * Obrađuje OCSP zahtev i generiše odgovor
+     * OCSP zahtev = "Da li je sertifikat sa serial brojem X valjan?"
+     * OCSP odgovor = "GOOD" ili "REVOKED" sa razlogom
+     */
+    public byte[] processOCSPRequest(byte[] ocspRequestBytes) throws Exception {
+        // Korak 1: Parsiramo OCSP zahtev
+        OCSPReq ocspRequest = new OCSPReq(ocspRequestBytes);
+        Req[] requests = ocspRequest.getRequestList();
+
+        // Korak 2: Pravimo OCSP odgovor builder
+        OCSPRespBuilder responseBuilder = new OCSPRespBuilder();
+
+        // Korak 3: Proveravamo da li ima zahteva
+        if (requests.length == 0) {
+            return responseBuilder.build(OCSPRespBuilder.MALFORMED_REQUEST, null).getEncoded();
+        }
+
+        // Korak 4: Obrađujemo prvi zahtev (pojednostavljeno - obično bi bilo više)
+        Req req = requests[0];
+        CertificateID certID = req.getCertID();
+
+        // Korak 5: Tražimo sertifikat po serial broju
+        // Izvlačimo serial number iz CertificateID objekta
+        BigInteger serialNumber = certID.getSerialNumber();
+        Certificate certificate = certificateRepository.findBySerialNumber(serialNumber.toString())
+                .orElse(null);
+
+        if (certificate == null) {
+            // Sertifikat ne postoji u našoj bazi
+            return responseBuilder.build(OCSPRespBuilder.UNAUTHORIZED, null).getEncoded();
+        }
+
+        // Korak 6: Tražimo issuer sertifikat (ko je izdao ovaj sertifikat)
+        Certificate issuerCert = certificate.getIssuerCertificate();
+        if (issuerCert == null) {
+            return responseBuilder.build(OCSPRespBuilder.UNAUTHORIZED, null).getEncoded();
+        }
+
+        // Korak 7: Pravimo basic OCSP odgovor
+        X509Certificate issuerX509 = parseX509Certificate(issuerCert.getCertificateData());
+        SubjectPublicKeyInfo subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(
+                issuerX509.getPublicKey().getEncoded()
+        );
+        BasicOCSPRespBuilder basicResponseBuilder = new BasicOCSPRespBuilder(
+                new RespID(ResponderID.getInstance(subjectPublicKeyInfo))
+        );
+
+        // Korak 8: Proveravamo status sertifikata
+        CertificateStatus certStatus;
+        if (certificate.isRevoked()) {
+            // Sertifikat je povučen - vraćamo REVOKED sa datumom i razlogom
+            Date revocationDate = Date.from(certificate.getRevocationDate()
+                    .atZone(ZoneId.systemDefault()).toInstant());
+            int reason = mapRevocationReasonToOCSP(certificate.getRevocationReason());
+            certStatus = new RevokedStatus(revocationDate, reason);
+        } else {
+            // Sertifikat je valjan - vraćamo GOOD
+            certStatus = CertificateStatus.GOOD;
+        }
+
+        // Korak 9: Dodajemo response sa statusom
+        Date thisUpdate = new Date(); // Kada je odgovor napravljen
+        Date nextUpdate = new Date(System.currentTimeMillis() + (24 * 60 * 60 * 1000)); // Sledeće ažuriranje za 24h
+
+        basicResponseBuilder.addResponse(certID, certStatus, thisUpdate, nextUpdate, null);
+
+        // Korak 10: Dodajemo nonce (broj koji se koristi samo jednom) ako postoji u zahtevu
+        Extension nonceExtension = ocspRequest.getExtension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce);
+        if (nonceExtension != null) {
+            basicResponseBuilder.setResponseExtensions(
+                    new Extensions(nonceExtension)
+            );
+        }
+
+        // Korak 11: Potpisujemo odgovor privatnim ključem CA-a
+        java.security.PrivateKey signingKey = cryptographyService.getDecryptedPrivateKey(issuerCert);
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider("BC").build(signingKey);
+
+        // Konvertujemo X509Certificate u X509CertificateHolder
+        X509CertificateHolder[] chain = new X509CertificateHolder[] {
+                new JcaX509CertificateHolder(issuerX509)
+        };
+
+        BasicOCSPResp basicResponse = basicResponseBuilder.build(
+                signer,
+                chain,
+                new Date()
+        );
+
+        // Korak 12: Vraćamo finalni OCSP odgovor
+        return responseBuilder.build(OCSPRespBuilder.SUCCESSFUL, basicResponse).getEncoded();
+    }
+
+    /**
+     * Obrađuje OCSP zahtev iz Base64 stringa (GET zahtev)
+     */
+    public byte[] processOCSPRequestFromBase64(String encodedRequest) throws Exception {
+        byte[] requestBytes = Base64.getDecoder().decode(encodedRequest);
+        return processOCSPRequest(requestBytes);
+    }
+
+    /**
+     * Jednostavna provera da li je sertifikat povučen
+     */
+    public boolean isCertificateRevoked(String serialNumber) {
+        return certificateRepository.findBySerialNumber(serialNumber)
+                .map(Certificate::isRevoked) // Vraća true/false
+                .orElse(false); // Ako sertifikat ne postoji, nije povučen
+    }
+
+    /**
+     * Parsira PEM sertifikat u X509Certificate objekat
+     */
+    private X509Certificate parseX509Certificate(String pemData) throws Exception {
+        // Uklanjamo PEM header/footer ako postoje
+        String certificateData = pemData
+                .replace("-----BEGIN CERTIFICATE-----", "")
+                .replace("-----END CERTIFICATE-----", "")
+                .replaceAll("\\s", "");
+
+        byte[] decodedCert = Base64.getDecoder().decode(certificateData);
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(decodedCert);
+        return (X509Certificate) factory.generateCertificate(inputStream);
+    }
+
+    /**
+     * Mapira naš enum razlog povlačenja u OCSP standard razlog
+     */
+    private int mapRevocationReasonToOCSP(
+            information.security.informationsecurity.model.certificate.RevocationReason reason) {
+        if (reason == null) {
+            return org.bouncycastle.asn1.x509.CRLReason.unspecified;
+        }
+
+        switch (reason) {
+            case KEY_COMPROMISE:
+                return org.bouncycastle.asn1.x509.CRLReason.keyCompromise;
+            case CA_COMPROMISE:
+                return org.bouncycastle.asn1.x509.CRLReason.cACompromise;
+            case AFFILIATION_CHANGED:
+                return org.bouncycastle.asn1.x509.CRLReason.affiliationChanged;
+            case SUPERSEDED:
+                return org.bouncycastle.asn1.x509.CRLReason.superseded;
+            case CESSATION_OF_OPERATION:
+                return org.bouncycastle.asn1.x509.CRLReason.cessationOfOperation;
+            case CERTIFICATE_HOLD:
+                return org.bouncycastle.asn1.x509.CRLReason.certificateHold;
+            default:
+                return org.bouncycastle.asn1.x509.CRLReason.unspecified;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,10 +6,10 @@ spring.datasource.password=admin
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.defer-datasource-initialization=true
-spring.sql.init.mode=never
+spring.sql.init.mode=always
 
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 


### PR DESCRIPTION
In this PR:

- Implemented certificate revocation checking mechanisms as required by the X.509 standard, providing both CRL (Certificate Revocation List) and OCSP (Online Certificate Status Protocol) support.
- CRLController: Exposes endpoints for retrieving CRLs in both binary and PEM formats
- CRLService: Generates CRLs containing all revoked certificates issued by a specific CA
- OCSPController: Provides real-time certificate status checking
- OCSPService: Processes OCSP requests and generates signed responses
- CRL Distribution Points: Automatically adds CRL endpoint to issued certificates
- Authority Information Access (AIA): Adds OCSP responder URL to certificates